### PR TITLE
Fix carousel peek by clipping at max-w-6xl boundary

### DIFF
--- a/plumbing/index.html
+++ b/plumbing/index.html
@@ -583,16 +583,16 @@
       </div>
     </div>
 
-    <!-- Carousel — left edge aligns with page content column; right overflows to hint more cards -->
-    <div style="overflow-x:hidden;">
+    <!-- Carousel — clipped at max-w-6xl boundary (1152px) so peek is consistent at any viewport width -->
+    <div class="max-w-6xl mx-auto overflow-hidden pb-4">
       <div id="reviews-track"
-           class="flex gap-4 pb-6"
-           style="overflow-x:auto;scroll-snap-type:x mandatory;scrollbar-width:none;-webkit-overflow-scrolling:touch;padding-left:max(1rem,calc((100vw - 72rem)/2 + 1rem));padding-right:1rem;">
+           class="flex gap-4 pb-2"
+           style="overflow-x:auto;scroll-snap-type:x mandatory;scrollbar-width:none;-webkit-overflow-scrolling:touch;padding-left:1rem;padding-right:1rem;">
 
         <!-- Patricia Sokolowski — September 2025 -->
         <a href="https://www.facebook.com/patricia.sokolowski.77/posts/pfbid031V9bse4hffuDY5nSddDvu9HcPGmEwNas87iZr77oB2NmHpfPmvoagsnDBGq8F8tAl"
            target="_blank" rel="noopener noreferrer"
-           class="snap-start shrink-0 w-[80vw] md:w-[360px] flex">
+           class="snap-start shrink-0 w-[80vw] md:w-80 flex">
           <blockquote class="bg-brand-clean rounded-plumber p-6 border border-gray-100 card-lift flex flex-col gap-4 h-full w-full">
             <div class="flex items-center gap-2">
               <span class="inline-flex items-center gap-1.5 bg-blue-50 text-blue-700 text-xs font-semibold px-2.5 py-1 rounded-full border border-blue-200">
@@ -614,7 +614,7 @@
         <!-- Jason Kell — October 2024 -->
         <a href="https://www.facebook.com/J.Moe320/posts/pfbid0SahkqEyFqYTFFXVC5C9S2Ak2YzqW8Rv6KehYWsEui14FmK9SGrwri6hy9Go84Qkrl"
            target="_blank" rel="noopener noreferrer"
-           class="snap-start shrink-0 w-[80vw] md:w-[360px] flex">
+           class="snap-start shrink-0 w-[80vw] md:w-80 flex">
           <blockquote class="bg-brand-clean rounded-plumber p-6 border border-gray-100 card-lift flex flex-col gap-4 h-full w-full">
             <div class="flex items-center gap-2">
               <span class="inline-flex items-center gap-1.5 bg-blue-50 text-blue-700 text-xs font-semibold px-2.5 py-1 rounded-full border border-blue-200">
@@ -636,7 +636,7 @@
         <!-- Michael Francis — November 2023 -->
         <a href="https://www.facebook.com/michael.francis.785519/posts/pfbid027UL3H9GQPMk1UkVKf26ey98LBAEwCQihvkfMUWmikH3eBA7W7yGNrUyNb2JEv3kyl"
            target="_blank" rel="noopener noreferrer"
-           class="snap-start shrink-0 w-[80vw] md:w-[360px] flex">
+           class="snap-start shrink-0 w-[80vw] md:w-80 flex">
           <blockquote class="bg-brand-clean rounded-plumber p-6 border border-gray-100 card-lift flex flex-col gap-4 h-full w-full">
             <div class="flex items-center gap-2">
               <span class="inline-flex items-center gap-1.5 bg-blue-50 text-blue-700 text-xs font-semibold px-2.5 py-1 rounded-full border border-blue-200">
@@ -656,7 +656,7 @@
         </a>
 
         <!-- Rainy Flores — May 2019 -->
-        <div class="snap-start shrink-0 w-[80vw] md:w-[360px] flex">
+        <div class="snap-start shrink-0 w-[80vw] md:w-80 flex">
           <blockquote class="bg-brand-clean rounded-plumber p-6 border border-gray-100 card-lift flex flex-col gap-4 h-full w-full">
             <div class="flex items-center gap-2">
               <span class="inline-flex items-center gap-1.5 bg-blue-50 text-blue-700 text-xs font-semibold px-2.5 py-1 rounded-full border border-blue-200">
@@ -676,7 +676,7 @@
         </div>
 
         <!-- Damian Swierbutowskii — May 2019 -->
-        <div class="snap-start shrink-0 w-[80vw] md:w-[360px] flex">
+        <div class="snap-start shrink-0 w-[80vw] md:w-80 flex">
           <blockquote class="bg-brand-clean rounded-plumber p-6 border border-gray-100 card-lift flex flex-col gap-4 h-full w-full">
             <div class="flex items-center gap-2">
               <span class="inline-flex items-center gap-1.5 bg-blue-50 text-blue-700 text-xs font-semibold px-2.5 py-1 rounded-full border border-blue-200">
@@ -696,7 +696,7 @@
         </div>
 
         <!-- Daryl Palumbo O'Leary — May 2019 -->
-        <div class="snap-start shrink-0 w-[80vw] md:w-[360px] flex">
+        <div class="snap-start shrink-0 w-[80vw] md:w-80 flex">
           <blockquote class="bg-brand-clean rounded-plumber p-6 border border-gray-100 card-lift flex flex-col gap-4 h-full w-full">
             <div class="flex items-center gap-2">
               <span class="inline-flex items-center gap-1.5 bg-blue-50 text-blue-700 text-xs font-semibold px-2.5 py-1 rounded-full border border-blue-200">


### PR DESCRIPTION
Previous approach clipped at viewport width, so on wide monitors all cards fit. Now the overflow:hidden is on the max-w-6xl container (1152px), ensuring the peek of card 4 is always visible regardless of viewport width. Cards narrowed to w-80 (320px) so 3 show + ~40% peek of card 4 within the 1152px window.

https://claude.ai/code/session_01HYasxrDXUJ8r2SUpsebKa9