### PR TITLE
Improve mobile PageSpeed: non-blocking fonts, fix forced reflow

### DIFF
--- a/plumbing/index.html
+++ b/plumbing/index.html
@@ -6,12 +6,14 @@
   <title>Maranto's Sewer &amp; Water Services – 24/7 Emergency Service | Bloomingdale, IL</title>
   <meta name="description" content="Licensed &amp; insured sewer and water specialists serving Bloomingdale, IL and surrounding areas. Fast 24/7 response for leaks, drains, water heaters &amp; more. Call (630) 421-0091." />
 
-  <!-- Fonts -->
+  <!-- Fonts: preconnect then load non-blocking to avoid render-blocking -->
   <link rel="preconnect" href="https://fonts.googleapis.com" />
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
-  <link href="https://fonts.googleapis.com/css2?family=Montserrat:wght@600;700;800&family=Inter:wght@400;500;600&display=swap" rel="stylesheet" />
+  <link rel="preload" as="style" href="https://fonts.googleapis.com/css2?family=Montserrat:wght@600;700;800&family=Inter:wght@400;500;600&display=swap" onload="this.onload=null;this.rel='stylesheet'" />
+  <noscript><link href="https://fonts.googleapis.com/css2?family=Montserrat:wght@600;700;800&family=Inter:wght@400;500;600&display=swap" rel="stylesheet" /></noscript>
 
   <!-- Tailwind CDN with custom config -->
+  <link rel="preconnect" href="https://cdn.tailwindcss.com" />
   <script src="https://cdn.tailwindcss.com"></script>
   <script>
     tailwind.config = {
@@ -738,7 +740,11 @@
         var fadeLeft   = document.getElementById('reviews-fade-left');
         var fadeRight  = document.getElementById('reviews-fade-right');
         var card       = track.querySelector(':scope > *');
-        function step() { return card.offsetWidth + 16; } /* gap-4 = 16px */
+        /* Cache step width; update on resize to avoid forced reflow on each click */
+        var cachedStep = card.offsetWidth + 16; /* gap-4 = 16px */
+        if (window.ResizeObserver) {
+          new ResizeObserver(function() { cachedStep = card.offsetWidth + 16; }).observe(card);
+        }
 
         function updateFades() {
           var atStart = track.scrollLeft < 8;
@@ -751,10 +757,10 @@
         updateFades();
 
         document.getElementById('reviews-prev').addEventListener('click', function () {
-          track.scrollBy({ left: -step(), behavior: 'smooth' });
+          track.scrollBy({ left: -cachedStep, behavior: 'smooth' });
         });
         document.getElementById('reviews-next').addEventListener('click', function () {
-          track.scrollBy({ left: step(), behavior: 'smooth' });
+          track.scrollBy({ left: cachedStep, behavior: 'smooth' });
         });
       })();
     </script>


### PR DESCRIPTION
- Load Google Fonts via rel=preload+onload instead of render-blocking stylesheet; should eliminate ~2,500ms render-blocking delay on FCP/LCP
- Add preconnect hint for cdn.tailwindcss.com
- Fix forced reflow in reviews carousel: cache offsetWidth on init and update via ResizeObserver instead of reading it on every button click

https://claude.ai/code/session_015tnKDgYmCTVdEU7PUiP39G