### PR TITLE
chore: add wrangler.toml to codify Cloudflare Pages output directory

### DIFF
--- a/wrangler.toml
+++ b/wrangler.toml
@@ -8,5 +8,5 @@
 # This file codifies the output directory so it is version-controlled
 # and cannot accidentally drift from what the build script produces.
 
-name = "maranto-sws"
+name = "maranto-sws-github-io"
 pages_build_output_dir = "dist"


### PR DESCRIPTION
Codifies pages_build_output_dir = "dist" in version control so the output directory cannot drift from what scripts/build.sh produces. Build command still requires manual configuration in the CF dashboard.

https://claude.ai/code/session_016wvqyhvFM5gnT2ftxHAYWu