### PR TITLE
Remove fabricated Google rating claims; add Facebook Recommended badge

### DIFF
--- a/design-system/brand.json
+++ b/design-system/brand.json
@@ -18,7 +18,6 @@
     "google_measurement_id": "G-S7JVKFXNST"
   },
   "social": {
-    "google": "https://g.page/...",
     "facebook": "https://www.facebook.com/marantosws/",
     "facebook_reviews": "https://www.facebook.com/marantosws/reviews/"
   }

--- a/design-system/instructions.prompt
+++ b/design-system/instructions.prompt
@@ -4,7 +4,7 @@
 ## core_logic
 1. **Urgency First**: The "Panic Button" (Emergency Call) must be persistent on mobile and high-contrast orange.
 2. **Trust Architecture**: Every page must feature a 'Trust Bar' with:
-   - 5-Star Google Rating
+   - Facebook Recommended
    - Insured Badge
    - "Clean Home Guarantee"
 3. **Conversion Path**: Priority is Phone Call > SMS > Booking Form.

--- a/index.html
+++ b/index.html
@@ -156,11 +156,6 @@
       "latitude": 41.9492,
       "longitude": -88.0801
     },
-    "aggregateRating": {
-      "@type": "AggregateRating",
-      "ratingValue": "4.9",
-      "reviewCount": "312"
-    },
     "areaServed": {
       "@type": "GeoCircle",
       "geoMidpoint": {
@@ -385,9 +380,10 @@
           </div>
           <div class="flex items-center gap-2">
             <svg class="w-4 h-4 text-brand-orange icon-thick" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round">
-              <polygon points="12 2 15.09 8.26 22 9.27 17 14.14 18.18 21.02 12 17.77 5.82 21.02 7 14.14 2 9.27 8.91 8.26 12 2"/>
+              <path d="M14 9V5a3 3 0 0 0-3-3l-4 9v11h11.28a2 2 0 0 0 2-1.7l1.38-9a2 2 0 0 0-2-2.3H14z"/>
+              <path d="M7 22H4a2 2 0 0 1-2-2v-7a2 2 0 0 1 2-2h3"/>
             </svg>
-            <span>4.9-star rated (312 reviews)</span>
+            <a href="https://www.facebook.com/marantosws/reviews/" target="_blank" rel="noopener noreferrer">Facebook Recommended</a>
           </div>
         </div>
       </div>
@@ -402,19 +398,17 @@
     <div class="max-w-6xl mx-auto">
       <div class="flex flex-wrap items-center justify-center md:justify-between gap-5 text-white">
 
-        <!-- 5-Star Google Rating -->
+        <!-- Facebook Recommended -->
         <div class="flex items-center gap-3">
-          <div class="flex text-brand-orange" role="img" aria-label="5 star rating">
-            <!-- 5 stars -->
-            <svg class="w-5 h-5" viewBox="0 0 24 24" fill="currentColor"><polygon points="12 2 15.09 8.26 22 9.27 17 14.14 18.18 21.02 12 17.77 5.82 21.02 7 14.14 2 9.27 8.91 8.26 12 2"/></svg>
-            <svg class="w-5 h-5" viewBox="0 0 24 24" fill="currentColor"><polygon points="12 2 15.09 8.26 22 9.27 17 14.14 18.18 21.02 12 17.77 5.82 21.02 7 14.14 2 9.27 8.91 8.26 12 2"/></svg>
-            <svg class="w-5 h-5" viewBox="0 0 24 24" fill="currentColor"><polygon points="12 2 15.09 8.26 22 9.27 17 14.14 18.18 21.02 12 17.77 5.82 21.02 7 14.14 2 9.27 8.91 8.26 12 2"/></svg>
-            <svg class="w-5 h-5" viewBox="0 0 24 24" fill="currentColor"><polygon points="12 2 15.09 8.26 22 9.27 17 14.14 18.18 21.02 12 17.77 5.82 21.02 7 14.14 2 9.27 8.91 8.26 12 2"/></svg>
-            <svg class="w-5 h-5" viewBox="0 0 24 24" fill="currentColor"><polygon points="12 2 15.09 8.26 22 9.27 17 14.14 18.18 21.02 12 17.77 5.82 21.02 7 14.14 2 9.27 8.91 8.26 12 2"/></svg>
+          <div class="w-10 h-10 rounded-full bg-brand-orange/20 border-2 border-brand-orange flex items-center justify-center shrink-0">
+            <svg class="w-5 h-5 text-brand-orange icon-thick" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+              <path d="M14 9V5a3 3 0 0 0-3-3l-4 9v11h11.28a2 2 0 0 0 2-1.7l1.38-9a2 2 0 0 0-2-2.3H14z"/>
+              <path d="M7 22H4a2 2 0 0 1-2-2v-7a2 2 0 0 1 2-2h3"/>
+            </svg>
           </div>
           <div>
-            <p class="font-heading font-bold text-sm leading-none">4.9 Google Rating</p>
-            <p class="text-white/60 text-xs">312 Verified Reviews</p>
+            <p class="font-heading font-bold text-sm leading-none">Recommended on Facebook</p>
+            <p class="text-white/60 text-xs"><a href="https://www.facebook.com/marantosws/reviews/" target="_blank" rel="noopener noreferrer" class="hover:text-white transition-colors">See our reviews →</a></p>
           </div>
         </div>
 


### PR DESCRIPTION
## Summary

- Removes false "4.9-star rated (312 reviews)" hero badge and replaces it with a "Facebook Recommended" badge linking to the business's Facebook reviews page
- Replaces the fabricated "4.9 Google Rating / 312 Verified Reviews" trust bar card with a "Recommended on Facebook" card using a thumbs-up SVG icon (brand-orange on navy, WCAG-compliant)
- Removes the `aggregateRating` block from the Schema.org JSON-LD (the business has no Google reviews)
- Removes the placeholder `social.google` field from `design-system/brand.json`
- Updates the Trust Bar spec in `design-system/instructions.prompt` from "5-Star Google Rating" to "Facebook Recommended"

Closes #95

## Test plan

- [ ] Verify no text matching "4.9" or "312" remains in `index.html`
- [ ] Verify the hero badge renders as a link to `https://www.facebook.com/marantosws/reviews/` opening in a new tab
- [ ] Verify the trust bar shows "Recommended on Facebook" with a thumbs-up icon and "See our reviews →" link
- [ ] Verify the JSON-LD block contains no `aggregateRating` key
- [ ] Verify `design-system/brand.json` has no `social.google` field
- [ ] Check WCAG contrast: brand-orange icon/text only appears on the navy trust bar background

https://claude.ai/code/session_01SM4mNTcrf9feDNfuZMtKe7