### PR TITLE
Present tagline consistently in hero and footer

### DIFF
--- a/index.html
+++ b/index.html
@@ -350,6 +350,8 @@
           <span class="text-brand-orange">24/7 — Day or Night.</span>
         </h1>
 
+        <p class="text-white/70 text-base italic mb-4">"If water goes through it, Maranto's can do it!"</p>
+
         <p class="text-white/80 text-lg md:text-xl leading-relaxed mb-8 max-w-lg">
           Burst pipe, clogged drain, or no hot water — our team arrives fast, guaranteed. We clean up when we're done.
         </p>

--- a/index.html
+++ b/index.html
@@ -351,8 +351,7 @@
         </h1>
 
         <p class="text-white/80 text-lg md:text-xl leading-relaxed mb-8 max-w-lg">
-          If water goes through it, Maranto's can do it! Burst pipe, clogged drain,
-          or no hot water — our team arrives fast, guaranteed. We clean up when we're done.
+          Burst pipe, clogged drain, or no hot water — our team arrives fast, guaranteed. We clean up when we're done.
         </p>
 
         <!-- CTA group -->


### PR DESCRIPTION
The tagline was blended into the hero's operational body copy, losing its identity as a distinct brand phrase. The footer already presented it correctly — quoted and italic, standing alone.

## Changes
- Removed the tagline from the hero body copy paragraph
- Added it back between the `<h1>` and the supporting copy as a standalone italic line, matching the footer's treatment

The tagline now reads as a brand statement on first impression, followed by the operational details, followed by the CTAs.

https://claude.ai/code/session_017ZhXjMSuAAchahUzCZW2Wy